### PR TITLE
Remove invalid SVG property

### DIFF
--- a/extension/resources/index.html
+++ b/extension/resources/index.html
@@ -25,7 +25,7 @@
 <defs>
 	<symbol id="has_more">
 		<g transform="translate(20 20)">
-			<circle r="18" fill="#800" stroke-width="2px" stroke="#fff" stroke-location="inside" />
+			<circle r="18" fill="#800" stroke-width="2px" stroke="#fff" />
 			<circle r="3" cx="-9" fill="#fff" />
 			<circle r="3" cx="0" fill="#fff" />
 			<circle r="3" cx="9" fill="#fff" />


### PR DESCRIPTION
`stroke-location` is not a valid part of SVG.

Ref:

* https://www.w3.org/TR/SVG/painting.html#StrokeProperties
* http://stackoverflow.com/a/28787545/1127699
* https://www.google.co.uk/search?q=%22stroke-location%22+site:svgwg.org&*

No real impact on layout & performance - but caused the page to fail validation.